### PR TITLE
Remove one declaration of info email field which was setted twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## next version:
 
 ## Version 0.1.1 (PATCH)
-- [x] [REFACTOR] Remove one declaration of info email field which was setted twice. \#[3](https://github.com/gencat/omniauth-idcat_mobil/pull/3)
+- [REFACTOR] Remove one declaration of info email field which was setted twice. \#[3](https://github.com/gencat/omniauth-idcat_mobil/pull/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## next version:
+
+## Version 0.1.1 (PATCH)
+- [x] [REFACTOR] Remove one declaration of info email field which was setted twice. \#[3](https://github.com/gencat/omniauth-idcat_mobil/pull/3)

--- a/lib/omniauth/idcat_mobil/version.rb
+++ b/lib/omniauth/idcat_mobil/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module IdCatMobil
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -37,7 +37,6 @@ module OmniAuth
           surname2: raw_info["surname2"],
           surnames: raw_info["surnames"],
           country_code: raw_info["countryCode"],
-          email: raw_info["email"],
         }
       end
 


### PR DESCRIPTION
The same `email` field was added twice inside the info group of fields.