### PR TITLE
Fix callback phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## next version:
 
+## Version 0.2.3 (PATCH)
+- FIX: do not delete the session state before checking it.
+- DOC: Correct mispelling in README
+
 ## Version 0.2.2 (PATCH)
-- Fix internal `log` method is wrongly invoked from `omniauth`.
+- FIX: Fix internal `log` method is wrongly invoked from `omniauth`.
 - Bump Ruby version to 2.7.5
 
 ## Version 0.2.1 (PATCH)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When users get authenticated, we still need to negotiate the access_token that w
 The access_token is obtained by performing a POST request to the provider. If this succeeds then we're ready to go and perform te `getUserInfo` request. This request is implemented in the `raw_info` method.
 After a successful `getUserInfo` the superclass of this strategy fills the `info` so that our host application can access it and finishes with its authentication task.
 
-## Incon assets
+## Icon assets
 We're including _IdCat mòbil_ icons in lib/decidim/idcat_mobil for the joy of the developer. They can be used to complement the OAuth2 button or alike.
 
 ## Development

--- a/lib/omniauth/idcat_mobil/version.rb
+++ b/lib/omniauth/idcat_mobil/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module IdCatMobil
-    VERSION = "0.2.2"
+    VERSION = "0.2.3"
   end
 end

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -89,7 +89,7 @@ module OmniAuth
       # That's what we do in this callback.
       def callback_phase
         idcat_log("In `callback_phase` with request params: #{request.params}")
-        idcat_log("Both should be equal otherwise a 'CSRF detected' error is raised: params state[#{request.params["state"]}] =? [#{session.delete("omniauth.state")}] session state.")
+        idcat_log("Both should be equal otherwise a 'CSRF detected' error is raised: params state[#{request.params["state"]}] =? [#{session["omniauth.state"]}] session state.")
         super
       end
 

--- a/spec/omniauth/strategies/idcat_mobil_spec.rb
+++ b/spec/omniauth/strategies/idcat_mobil_spec.rb
@@ -29,9 +29,9 @@ describe OmniAuth::Strategies::IdCatMobil do
       "name"            => "Oriol",
       "prefix"          => "972",
       "phone"           => "505152",
-      "surname1"        => "Junqueras",
-      "surname2"        => "Vies",
-      "surnames"        => "Junqueras Vies",
+      "surname1"        => "Junquerol",
+      "surname2"        => "Balaguer",
+      "surnames"        => "Junquerol Balaguer",
       "countryCode"    => "CAT",
     }    
   end


### PR DESCRIPTION
A previous refactor introduced a bug that provokes a crash during the `callback_phase`. It turns out that the added log traces were deleting the `state` from the session before this state was being checked by oauth2.
This PR solves this problem.