### PR TITLE
Fix access token response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,24 @@
 
 ## next version:
 
+## Version 0.2.4 (PATCH)
+- FIX: do not delete the session state before checking it.
+- DOC: Change CHANGELOG format, prefix with change type.
+
 ## Version 0.2.3 (PATCH)
 - FIX: do not delete the session state before checking it.
 - DOC: Correct mispelling in README
 
 ## Version 0.2.2 (PATCH)
 - FIX: Fix internal `log` method is wrongly invoked from `omniauth`.
-- Bump Ruby version to 2.7.5
+- DEP: Bump Ruby version to 2.7.5
 
 ## Version 0.2.1 (PATCH)
-- Apply security upgrades
-- Add a .ruby-version file
+- DEP: Apply security upgrades
+- CONF: Add a .ruby-version file
 
 ## Version 0.2.0 (MINOR)
-- Remove Gemfile.lock to avoid forcing the versioning of apps using this gem.
+- REFACT: Remove Gemfile.lock to avoid forcing the versioning of apps using this gem.
 
 ## Version 0.1.1 (PATCH)
-- [REFACTOR] Remove one declaration of info email field which was setted twice. \#[3](https://github.com/gencat/omniauth-idcat_mobil/pull/3)
+- REFACT: Remove one declaration of info email field which was setted twice. \#[3](https://github.com/gencat/omniauth-idcat_mobil/pull/3)

--- a/lib/omniauth/idcat_mobil/version.rb
+++ b/lib/omniauth/idcat_mobil/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module IdCatMobil
-    VERSION = "0.2.3"
+    VERSION = "0.2.4"
   end
 end

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -94,9 +94,10 @@ module OmniAuth
       end
 
       def raw_info
-        idcat_log("Access token response was: #{access_token.try(:response)}")
-        idcat_log("Performing getUserInfo...")
-        unless @raw_info
+        if @raw_info
+          idcat_log("Access token response was: #{access_token.try(:response)}")
+        else
+          idcat_log("Performing getUserInfo...")
           response= access_token.get(options.user_info_path)
           result= %i(status headers body).collect  {|m| response.send(m)}
           idcat_log("getUserInfo response status/headers/body: #{result}")

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -94,7 +94,7 @@ module OmniAuth
       end
 
       def raw_info
-        idcat_log("Access token response was: #{access_token.response}")
+        idcat_log("Access token response was: #{access_token.try(:response)}")
         idcat_log("Performing getUserInfo...")
         unless @raw_info
           response= access_token.get(options.user_info_path)


### PR DESCRIPTION
Requesting for the `access_token.response` before having performed any request with that token results in a crash due to MethodNotFound.
This PR solves this problem.