### PR TITLE
Upgrade omniauth to 2.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 /pkg/
 /spec/reports/
 /tmp/
-Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## next version:
 
+## Version 0.4.0 (MINOR)
+- Upgrade omniauth to 2.0.4
+
 ## Version 0.3.0 (MINOR)
 - CI: Introduce continuous integration via GitHub Actions.
 - CI: Apply `rubocop` recommendations.

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development, :test do
+  gem "byebug"
   gem "rubocop"
   gem "rubocop-rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,92 @@
+PATH
+  remote: .
+  specs:
+    omniauth-idcat_mobil (0.4.0)
+      omniauth (~> 2.0.4)
+      omniauth-oauth2 (>= 1.7.2, < 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.2)
+    byebug (11.1.3)
+    diff-lcs (1.4.4)
+    faraday (2.3.0)
+      faraday-net_http (~> 2.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (2.0.3)
+    hashie (5.0.0)
+    jwt (2.3.0)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
+    oauth2 (1.4.9)
+      faraday (>= 0.17.3, < 3.0)
+      jwt (>= 1.0, < 3.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
+      rack (>= 1.2, < 3)
+    omniauth (2.0.4)
+      hashie (>= 3.4.6)
+      rack (>= 1.6.2, < 3)
+      rack-protection
+    omniauth-oauth2 (1.7.2)
+      oauth2 (~> 1.4)
+      omniauth (>= 1.9, < 3)
+    parallel (1.21.0)
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
+    rack (2.2.3)
+    rack-protection (2.2.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rainbow (3.1.1)
+    rake (12.3.3)
+    regexp_parser (2.2.0)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.25.0)
+      parallel (~> 1.10)
+      parser (>= 3.1.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    rubocop-rspec (2.8.0)
+      rubocop (~> 1.19)
+    ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
+    unicode-display_width (2.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.2, >= 2.2.10)
+  byebug
+  omniauth-idcat_mobil!
+  rack (>= 2.1.4)
+  rack-test
+  rake (~> 12.3, >= 12.3.3)
+  rspec (~> 3.0)
+  rubocop
+  rubocop-rspec
+
+BUNDLED WITH
+   2.3.6

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For IdCat mòbil we still need to perform an extra step during the +callback_pha
 
 ### request_phase
 
-`omniauth-idcat_mobil` does not implement this method, instead we rely in the default implementation in `OmniAuth::Strategies::OAuth2`.
+`omniauth-idcat_mobil` does not implement this method, instead we rely on the default implementation in `OmniAuth::Strategies::OAuth2`.
 It simply redirects the user to the authentiction provider to authenticate.
 When users finish with the authentication workflow in IdCat mòbil, this authentication provider redirects them to our `callback_phase`.
 

--- a/lib/omniauth/idcat_mobil/version.rb
+++ b/lib/omniauth/idcat_mobil/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module IdCatMobil
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -112,7 +112,7 @@ module OmniAuth
       # The url where the provider should redirect the users to after authenticating.
       # https://github.com/intridea/omniauth-oauth2/issues/81
       def callback_url
-        full_host + script_name + callback_path
+        File.join([full_host, script_name, callback_path].compact)
       end
 
       # --------------------------------------------------

--- a/omniauth-idcat_mobil.gemspec
+++ b/omniauth-idcat_mobil.gemspec
@@ -24,9 +24,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth", "~> 1.5"
-  spec.add_dependency "omniauth-oauth2", ">= 1.4.0", "< 2.0"
+  spec.add_dependency "omniauth", "~> 2.0.4"
+  spec.add_dependency "omniauth-oauth2", ">= 1.7.2", "< 2.0"
   spec.add_development_dependency "bundler", "~> 2.2", ">= 2.2.10"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake", "~> 12.3", ">= 12.3.3"
   spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/spec/omni_auth/strategies/id_cat_mobil_spec.rb
+++ b/spec/omni_auth/strategies/id_cat_mobil_spec.rb
@@ -51,7 +51,8 @@ describe OmniAuth::Strategies::IdCatMobil do
   before do
     allow(strategy).to receive(:access_token).and_return(access_token)
     OmniAuth.config.full_host= "https://test.participa.gencat.cat"
-    allow(strategy).to receive(:script_name).and_return("/users")
+    allow(strategy).to receive(:script_name).and_return("")
+    allow(strategy).to receive(:callback_path).and_return("/users/auth/idcat_mobil/callback")
   end
 
   describe "client options" do


### PR DESCRIPTION
#### :tophat: What? Why?
As Decidim `v0.25` depends on omniauth `v2.0.4` this module should also upgrade that dependency to be compatible with Decidim.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [ ] Add documentation regarding the feature 
- [ ] Add tests
- [ ] Another subtask
