### PR TITLE
Bump omniauth and hashie versions

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -25,7 +25,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-rubydeps-${{ hashFiles('Gemfile.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2.0.0
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
@@ -25,7 +25,7 @@ jobs:
           ruby-version: ${{ env.RUBY_VERSION }}
 
       - name: Recover Ruby dependency cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ./vendor/bundle
           key: ${{ runner.OS }}-rubydeps-${{ hashFiles('Gemfile.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next version:
 
+## Version 0.6.0 (MINOR)
+- Bump omniauth dependency to v2.1 series.
+- Force Hashie >= 5.0.0.
+
 ## Version 0.5.0 (MINOR)
 - Send the client_id and the client_secret during the AuthToken retrieval.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    omniauth-idcat_mobil (0.5.0)
-      omniauth (~> 2.0.4)
+    omniauth-idcat_mobil (0.6.0)
+      hashie (>= 5.0.0)
+      omniauth (~> 2.1.2)
       omniauth-oauth2 (>= 1.7.2, < 2.0)
 
 GEM
@@ -17,6 +18,7 @@ GEM
     faraday-net_http (2.0.3)
     hashie (5.0.0)
     jwt (2.3.0)
+    logger (1.7.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
     oauth2 (1.4.9)
@@ -25,9 +27,10 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (2.0.4)
+    omniauth (2.1.4)
       hashie (>= 3.4.6)
-      rack (>= 1.6.2, < 3)
+      logger
+      rack (>= 2.2.3)
       rack-protection
     omniauth-oauth2 (1.7.2)
       oauth2 (~> 1.4)

--- a/lib/omniauth/idcat_mobil/version.rb
+++ b/lib/omniauth/idcat_mobil/version.rb
@@ -2,6 +2,6 @@
 
 module Omniauth
   module IdCatMobil
-    VERSION = "0.5.0"
+    VERSION = "0.6.0"
   end
 end

--- a/lib/omniauth/strategies/idcat_mobil.rb
+++ b/lib/omniauth/strategies/idcat_mobil.rb
@@ -123,7 +123,7 @@ module OmniAuth
       # --------------------------------------------------
 
       def idcat_log(msg)
-        idcat_logger.debug(msg)
+        idcat_logger.info("[idcat_mobil] #{msg}")
       end
 
       def idcat_logger

--- a/omniauth-idcat_mobil.gemspec
+++ b/omniauth-idcat_mobil.gemspec
@@ -24,6 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  # Hashie >= 5.0.0 is required for compatibility with newer ActiveSupport versions.
+  # Older versions of Hashie have conflicts with ActiveSupport's Hash extensions.
   spec.add_dependency "hashie", ">=5.0.0"
   spec.add_dependency "omniauth", "~> 2.1.2"
   spec.add_dependency "omniauth-oauth2", ">= 1.7.2", "< 2.0"

--- a/omniauth-idcat_mobil.gemspec
+++ b/omniauth-idcat_mobil.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "omniauth", "~> 2.0.4"
+  spec.add_dependency "hashie", ">=5.0.0"
+  spec.add_dependency "omniauth", "~> 2.1.2"
   spec.add_dependency "omniauth-oauth2", ">= 1.7.2", "< 2.0"
   spec.add_development_dependency "bundler", "~> 2.2", ">= 2.2.10"
   spec.add_development_dependency "rake", "~> 12.3", ">= 12.3.3"

--- a/spec/omni_auth/auth_hash_spec.rb
+++ b/spec/omni_auth/auth_hash_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe OmniAuth::AuthHash do
+  let(:auth_hash) do
+    OmniAuth::AuthHash.new(
+      provider: "idcat_mobil",
+      uid: "123456789",
+      info: {
+        email: "email@example.net",
+        name: "Oriol",
+        surname1: "Junquerol",
+        surname2: "Balaguer"
+      },
+      credentials: {
+        token: "fake_token",
+        expires: false
+      },
+      extra: {
+        identifier_type: "1",
+        method: "idcatmobil",
+        status: "ok"
+      }
+    )
+  end
+
+  describe "indifferent access" do
+    it "is accessible with string keys at root level" do
+      expect(auth_hash["provider"]).to eq("idcat_mobil")
+      expect(auth_hash["uid"]).to eq("123456789")
+      expect(auth_hash["info"]).to be_a(Hash)
+      expect(auth_hash["credentials"]).to be_a(Hash)
+      expect(auth_hash["extra"]).to be_a(Hash)
+    end
+
+    it "is accessible with symbol keys at root level" do
+      expect(auth_hash[:provider]).to eq("idcat_mobil")
+      expect(auth_hash[:uid]).to eq("123456789")
+      expect(auth_hash[:info]).to be_a(Hash)
+      expect(auth_hash[:credentials]).to be_a(Hash)
+      expect(auth_hash[:extra]).to be_a(Hash)
+    end
+
+    it "is accessible with string keys in nested hashes" do
+      expect(auth_hash["info"]["email"]).to eq("email@example.net")
+      expect(auth_hash["info"]["name"]).to eq("Oriol")
+      expect(auth_hash["credentials"]["token"]).to eq("fake_token")
+      expect(auth_hash["extra"]["method"]).to eq("idcatmobil")
+    end
+
+    it "is accessible with symbol keys in nested hashes" do
+      expect(auth_hash[:info][:email]).to eq("email@example.net")
+      expect(auth_hash[:info][:name]).to eq("Oriol")
+      expect(auth_hash[:credentials][:token]).to eq("fake_token")
+      expect(auth_hash[:extra][:method]).to eq("idcatmobil")
+    end
+
+    it "supports mixed string and symbol access" do
+      expect(auth_hash["info"][:email]).to eq("email@example.net")
+      expect(auth_hash[:info]["name"]).to eq("Oriol")
+      expect(auth_hash["credentials"][:token]).to eq("fake_token")
+      expect(auth_hash[:extra]["method"]).to eq("idcatmobil")
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: What? Why?
This gem stopped working when applications were accessing the AuthHash (which contains :info, :provider, etc.)  were accessing the values with keys of Symbol type, instead of String. i.e.: The following code `ah= OmniAuth::AuthHash.new(provider: :idcat_mobil); ah.slice :provider` was returning an empty Hash, `{}`, instead of `#<OmniAuth::AuthHash provider=:idcat_mobil>`.

This is because `OmniAuth::AuthHash` refused to use old Hashie in favor of the standard Hash class. With `Hashie` v5.0.0 `OmniAuth::AuthHash` uses Hashie again.

```
# expected behavior to access `ah` with either string or symbol keys
ah= OmniAuth::AuthHash.new(provider: :idcat_mobil)
ah.method(:slice)
=> #<Method: OmniAuth::AuthHash(Hashie::Mash)#slice(*keys)
ah.slice :provider
=> {"provider"=>:idcat_mobil}

# only accepts string keys
ah= OmniAuth::AuthHash.new(provider: :idcat_mobil)
ah.method(:slice).inspect
=> "#<Method: OmniAuth::AuthHash(Hash)#slice(*)>"
ah.slice(:provider, :uid, :info)
=> {}
```


The stacktrace in production is:

```
WARN -- : [a34b1258-18e6-4d3d-9ac7-0ad4495e310d] You are setting a key that conflicts with a built-in method SnakyHash::StringKeyed#method defined in Kernel. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
INFO -- : [a34b1258-18e6-4d3d-9ac7-0ad4495e310d] Processing by Decidim::Devise::OmniauthRegistrationsController#idcat_mobil as HTML
INFO -- : [a34b1258-18e6-4d3d-9ac7-0ad4495e310d]   Parameters: {"code"=>"[FILTERED]", "state"=>"a654797f2bfd605c46d9c3c2e1b835d94c007b86a3c68c36"}
INFO -- : [a34b1258-18e6-4d3d-9ac7-0ad4495e310d] Completed 500 Internal Server Error in 1ms (ActiveRecord: 0.0ms | Allocations: 794)
ERROR -- : [a34b1258-18e6-4d3d-9ac7-0ad4495e310d] @app.call rescued from: undefined method `with_indifferent_access' for nil:NilClass => .../decidim-core/lib/decidim/attribute_object/form.rb:82:in `hash_from'
.../decidim-core/lib/decidim/attribute_object/form.rb:72:in `from_params'
.../decidim-core/app/controllers/concerns/decidim/form_factory.rb:65:in `from_params'
.../decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb:18:in `create'
.../decidim-core/app/controllers/decidim/devise/omniauth_registrations_controller.rb:50:in `action_missing'
...
```